### PR TITLE
Cmp/div optimizations, tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ erl_crash.dump
 _build
 rebar.lock
 *.crashdump
+*~
+.rebar3/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ otp_release:
   - 19.1
   - 18.2.1
 script:
-  - ./rebar3 do xref,eunit,dialyzer,coveralls send
+  - ./rebar3 do xref,eunit,dialyzer,proper,coveralls send

--- a/include/decimal.hrl
+++ b/include/decimal.hrl
@@ -42,7 +42,7 @@
 -define(exponent(X),element(2, ?to_decimal(X))).
 -define(is_zero(X),decimal:is_zero(?to_decimal(X))).
 -define(is_signed(X),case ?sign(X) of -1 -> true; _ -> false end).
--define(cmp(X,Y),decimal:cmp(?to_decimal(X),?to_decimal(Y),?d_context)).
+-define(cmp(X,Y),decimal:cmp(?to_decimal(X),?to_decimal(Y))).
 -define(le(X,Y),(?cmp(X,Y) =< 0)).
 -define(lt(X,Y),(?cmp(X,Y) < 0)).
 -define(ge(X,Y),(?cmp(X,Y) >= 0)).

--- a/include/decimal.hrl
+++ b/include/decimal.hrl
@@ -42,7 +42,7 @@
 -define(exponent(X),element(2, ?to_decimal(X))).
 -define(is_zero(X),decimal:is_zero(?to_decimal(X))).
 -define(is_signed(X),case ?sign(X) of -1 -> true; _ -> false end).
--define(cmp(X,Y),decimal:cmp(?to_decimal(X),?to_decimal(Y))).
+-define(cmp(X,Y),decimal:cmp(?to_decimal(X),?to_decimal(Y), ?d_context)).
 -define(le(X,Y),(?cmp(X,Y) =< 0)).
 -define(lt(X,Y),(?cmp(X,Y) < 0)).
 -define(ge(X,Y),(?cmp(X,Y) >= 0)).

--- a/rebar.config
+++ b/rebar.config
@@ -1,1 +1,8 @@
 {xref_checks, [undefined_function_calls]}.
+
+{plugins, [rebar3_proper]}.
+{profiles,
+    [{test, [
+             {deps, [proper]}
+    ]}
+]}.

--- a/src/decimal.erl
+++ b/src/decimal.erl
@@ -18,7 +18,7 @@
 
 %% Compare
 -export([
-         cmp/2,
+         fast_cmp/2,
          cmp/3
         ]).
 
@@ -153,19 +153,19 @@ cmp(A, B, #{ precision := Precision, rounding := Rounding }) ->
     end.
 
 %% Fast compare without rounding
-cmp({0, _}, {0, _}) ->
+fast_cmp({0, _}, {0, _}) ->
     0;
-cmp({Int1, _}, {Int2, _}) when Int1 >= 0, Int2 =< 0 ->
+fast_cmp({Int1, _}, {Int2, _}) when Int1 >= 0, Int2 =< 0 ->
     1;
-cmp({Int1, _}, {Int2, _}) when Int1 =< 0, Int2 >= 0 ->
+fast_cmp({Int1, _}, {Int2, _}) when Int1 =< 0, Int2 >= 0 ->
     -1;
-cmp({Int, E}, {Int, E}) ->
+fast_cmp({Int, E}, {Int, E}) ->
     0;
-cmp({Int1, E}, {Int2, E}) when Int1 > Int2 ->
+fast_cmp({Int1, E}, {Int2, E}) when Int1 > Int2 ->
     1;
-cmp({Int1, E}, {Int2, E}) when Int1 < Int2 ->
+fast_cmp({Int1, E}, {Int2, E}) when Int1 < Int2 ->
     -1;
-cmp({Int1, E1}, {Int2, E2}) ->
+fast_cmp({Int1, E1}, {Int2, E2}) ->
     Emin = min(E1, E2),
     B1 = Int1*pow_of_ten(E1-Emin),
     B2 = Int2*pow_of_ten(E2-Emin),
@@ -256,9 +256,6 @@ zero_exp_(Base, Exp) -> {Base, Exp}.
 %% =============================================================================
 
 -spec pow_of_ten(non_neg_integer()) -> pos_integer().
-
-pow_of_ten(101) -> %speedup for default precision settings
-    100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000;
 pow_of_ten(N) ->
     if N > 0 -> int_pow(10, N, 1);
        true  -> 1

--- a/test/prop_basic.erl
+++ b/test/prop_basic.erl
@@ -4,7 +4,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -include("decimal.hrl").
--import(decimal, [divide/3, mult/2, add/2, sub/2, cmp/2, is_zero/1, to_binary/1, to_decimal/2]).
+-import(decimal, [divide/3, mult/2, add/2, sub/2, fast_cmp/2, is_zero/1, to_binary/1, to_decimal/2]).
 
 %% check (R1 + R2) - R2 == R1
 prop_add_sub() ->
@@ -42,4 +42,4 @@ rounding_algorithm() ->
 
 eq(A,B, #{precision := P}) ->
     Diff = decimal:abs(sub(decimal:abs(A),decimal:abs(B))),
-    cmp(Diff, {1,-P}) =< 0 orelse io:format("A: ~p~nB: ~p~nDiff: ~p~nPrec: ~p~n", [A, B, Diff, P]) .
+    fast_cmp(Diff, {1,-P}) =< 0 orelse io:format("A: ~p~nB: ~p~nDiff: ~p~nPrec: ~p~n", [A, B, Diff, P]) .

--- a/test/prop_basic.erl
+++ b/test/prop_basic.erl
@@ -1,0 +1,45 @@
+-module(prop_basic).
+
+-include_lib("proper/include/proper.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-include("decimal.hrl").
+-import(decimal, [divide/3, mult/2, add/2, sub/2, cmp/2, is_zero/1, to_binary/1, to_decimal/2]).
+
+%% check (R1 + R2) - R2 == R1
+prop_add_sub() ->
+    ?FORALL({D1, D2, Opts}, {decimal(), decimal(), opts()},
+            eq(D1, sub(add(D1, D2), D2), Opts)).
+
+%% check (R1*R2)/R2 == R1
+prop_mult_div() ->
+    ?FORALL({D1, D2, Opts}, {decimal(), non_zero_decimal(), opts()},
+            eq(D1, divide(mult(D1, D2), D2, Opts), Opts)).
+
+%% check ?max(D1,D2) - ?min(D1,D2) >= 0
+prop_max_min_ge() ->
+    ?FORALL({D1, D2}, {decimal(), decimal()},
+            ?ge(?sub(?max(D1,D2), ?min(D1,D2)), ?d_zero)).
+
+prop_to_from_binary() ->
+    ?FORALL({D, #{precision := P, rounding := R} = Opts}, {decimal(), opts()},
+            eq(decimal:round(R, D, P), to_decimal(to_binary(D) ,Opts), Opts)).
+
+%% ---------------------------------------------------------------
+%% Generators
+%% ---------------------------------------------------------------
+non_zero_decimal() ->
+    ?SUCHTHAT(Dec, decimal(), not is_zero(Dec)).
+
+decimal() ->
+    {integer(), integer()}.
+
+opts() ->
+    ?LET({R,P}, {rounding_algorithm(), pos_integer()}, #{precision => P, rounding => R}).
+
+rounding_algorithm() ->
+    oneof([round_floor,round_ceiling,round_half_up,round_half_down,round_down]).
+
+eq(A,B, #{precision := P}) ->
+    Diff = decimal:abs(sub(decimal:abs(A),decimal:abs(B))),
+    cmp(Diff, {1,-P}) =< 0 orelse io:format("A: ~p~nB: ~p~nDiff: ~p~nPrec: ~p~n", [A, B, Diff, P]) .

--- a/test/src/decimal_tests.erl
+++ b/test/src/decimal_tests.erl
@@ -380,7 +380,7 @@ cmp_test_() ->
            decimal:to_binary(B)
           ]),
       fun() ->
-          R = decimal:cmp(A, B)
+          R = decimal:fast_cmp(A, B)
       end} || {A, B, R} <- Tests
     ].
 

--- a/test/src/decimal_tests.erl
+++ b/test/src/decimal_tests.erl
@@ -345,6 +345,7 @@ cmp_test_() ->
          { {1,0}, {0,0},   1 },
          { {-1,0}, {0,0}, -1 },
          { {0,0}, {1,0},  -1 },
+         { {1,0}, {2,-1},  1 },
 
          { {0, -100}, {0, 100}, 0},
          { {10, 0}, {1, 1}, 0 },
@@ -365,6 +366,21 @@ cmp_test_() ->
           ]),
       fun() ->
           R = decimal:cmp(A, B, Opts)
+      end} || {A, B, R} <- Tests
+    ] ++
+    [
+     {iolist_to_binary(
+          [
+           decimal:to_binary(A),
+           case R of
+               1 -> $>;
+               0 -> $=;
+               -1 -> $<
+           end,
+           decimal:to_binary(B)
+          ]),
+      fun() ->
+          R = decimal:cmp(A, B)
       end} || {A, B, R} <- Tests
     ].
 


### PR DESCRIPTION
Чуть потюнил decimal, тесты и перфоманс замеры прилагаются.

Test source:
-----------------
```erlang
perf_test(N) ->
    Precs = [100],
    Rounds = [round_floor,round_ceiling,round_half_up,round_half_down,round_down],
    FloatList = [X/10000 + X*X || X <- lists:seq(1, N)],
    DecList = [to_decimal(F, #{precision => 100,rounding => round_half_up}) || F <- FloatList],

    Cmp3TotalTime =
    [begin
         Ctx = #{precision => P,rounding => R},
         {DivTime, _} = timer:tc(fun()-> lists:foldl(fun(D,Acc)-> cmp(Acc, D, Ctx), D end, {1,2}, DecList), ok end),
         io:format("[~p] Cmp/3 speed: ~p op/sec~n", [R, round(N / (DivTime / 1000000))]),
         DivTime
     end || P <- Precs, R <- Rounds],

    {Cmp2, _} = timer:tc(fun()-> lists:foldl(fun(D,Acc)-> cmp(Acc, D), D end, {1,2}, DecList), ok end),
    io:format("~nCmp/2 speed: ~p op/sec~n", [round(N / (Cmp2 / 1000000))]),
    io:format("Cmp speedup (%): ~p~n~n", [(((lists:sum(Cmp3TotalTime) / length(Cmp3TotalTime)) / Cmp2) - 1) * 100]),

    OldDivTotalTime=
    [begin
         Ctx = #{precision => P,rounding => R},
         {DivTime, _} = timer:tc(fun()-> lists:foldl(fun(D,Acc)-> divide_old(Acc, D, Ctx), D end, {1,2}, DecList), ok end),
         io:format("[~p] Old Div speed: ~p op/sec~n", [R, round(N / (DivTime / 1000000))]),
         DivTime
     end || P <- Precs, R <- Rounds],

    io:nl(),
    NewDivTotalTime=
    [begin
         Ctx = #{precision => P,rounding => R},
         {DivTime, _} = timer:tc(fun()-> lists:foldl(fun(D,Acc)-> divide(Acc, D, Ctx), D end, {1,2}, DecList), ok end),
         io:format("[~p] Div speed: ~p op/sec~n", [R, round(N / (DivTime / 1000000))]),
         DivTime
     end || P <- Precs, R <- Rounds],

    io:format("Div speedup (%): ~p~n", [(lists:sum(OldDivTotalTime) / lists:sum(NewDivTotalTime) -1) * 100]),
    ok.
```

Results:
------------------

[round_floor] Cmp/3 speed:              13878095 op/sec
[round_ceiling] Cmp/3 speed:            16089069 op/sec
[round_half_up] Cmp/3 speed:            15739356 op/sec
[round_half_down] Cmp/3 speed:          16010759 op/sec
[round_down] Cmp/3 speed:               12946492 op/sec

Cmp/2 speed:                            24848425 op/sec
Cmp speedup (%):                        67.69

[round_floor] Old Div speed:            1034022 op/sec
[round_ceiling] Old Div speed:          1031561 op/sec
[round_half_up] Old Div speed:          883968 op/sec
[round_half_down] Old Div speed:        879010 op/sec
[round_down] Old Div speed:             1154255 op/sec

[round_floor] Div speed:                1268828 op/sec
[round_ceiling] Div speed:              1209800 op/sec
[round_half_up] Div speed:              1044549 op/sec
[round_half_down] Div speed:            1059044 op/sec
[round_down] Div speed:                 1380506 op/sec
Div speedup (%):                        19.59
