### PR TITLE
decimal: fix handling of -0.0 for OTP-26.1/27.0

### DIFF
--- a/src/decimal_conv.erl
+++ b/src/decimal_conv.erl
@@ -98,7 +98,7 @@ parse_exp(_,_,_,_) ->
 %%% From float
 %% =============================================================================
 
-from_float(0.0) ->
+from_float(Num) when Num == 0.0 ->
     {0, 0};
 from_float(Float) when is_float(Float) ->
     {Frac, Exp} = mantissa_exponent(Float),


### PR DESCRIPTION
Matching of floating-point zeroes will change in OTP-27 so that -0.0 will no longer match a non-negative 0.0. OTP-26.1 warns about such constructs, which in decimal results in:

===> Compiling decimal
src/decimal_conv.erl:101:12: Warning: matching on the float 0.0 will no longer also match -0.0 in OTP 27. If you specifically intend to match 0.0 alone, write +0.0 instead.

Fixed by switching from a match to a numerical comparison.